### PR TITLE
 Added shutil and platform imports

### DIFF
--- a/ProPresenter7_ENG_to_Russian_Adjuster.py
+++ b/ProPresenter7_ENG_to_Russian_Adjuster.py
@@ -1,7 +1,9 @@
 import json
-import xml.etree.ElementTree as ET
 import os
+import platform
+import shutil
 import sys
+import xml.etree.ElementTree as ET
 import zipfile
 
 # Author - Daniel Agafonov (https://github.com/AlphaHasher)
@@ -186,4 +188,3 @@ print("Moving bible to ProPresenter directory")
 move_rvbible_propresenter_folder(rvbible_location)
 
 print("Done! Please restart ProPresenter and check if the bible is correctly installed.")
-input("Press enter to close...")

--- a/ProPresenter7_ENG_to_Russian_Adjuster.py
+++ b/ProPresenter7_ENG_to_Russian_Adjuster.py
@@ -188,3 +188,4 @@ print("Moving bible to ProPresenter directory")
 move_rvbible_propresenter_folder(rvbible_location)
 
 print("Done! Please restart ProPresenter and check if the bible is correctly installed.")
+input("Press enter to close...")


### PR DESCRIPTION
`shutil` and `platform` weren't imported. I also sorted the imports

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the issue where the script could not run due to missing imports for `shutil` and `platform`. Additionally, it improves code organization by sorting the import statements.

- **Bug Fixes**:
    - Added missing imports for `shutil` and `platform` to ensure the script runs correctly.
- **Enhancements**:
    - Sorted the import statements for better code organization.

<!-- Generated by sourcery-ai[bot]: end summary -->